### PR TITLE
Optimize maximum threads to saturate decoding capacity

### DIFF
--- a/jetstream/core/implementations/mock/server.py
+++ b/jetstream/core/implementations/mock/server.py
@@ -24,9 +24,6 @@ from jetstream.core import server_lib
 
 
 _PORT = flags.DEFINE_integer('port', 9000, 'port to listen on')
-_THREADS = flags.DEFINE_integer(
-    'threads', 64, 'number of worker threads in thread pool'
-)
 _CONFIG = flags.DEFINE_string(
     'config',
     'InterleavedCPUTestServer',
@@ -41,7 +38,6 @@ def main(argv: Sequence[str]):
   # We separate credential from run so that we can unit test it with local credentials.
   # TODO: Add grpc credentials for OSS.
   jetstream_server = server_lib.run(
-      threads=_THREADS.value,
       port=_PORT.value,
       config=server_config,
       devices=devices,

--- a/jetstream/core/server_test.py
+++ b/jetstream/core/server_test.py
@@ -59,7 +59,6 @@ class ServerTest(parameterized.TestCase):
     credentials = grpc.local_server_credentials()
 
     _ = server_lib.run(
-        threads=25,
         port=port,
         config=config,
         devices=devices,


### PR DESCRIPTION
- Number of RPC handlers worker threads should be at least equal to the decoding batch size to fully saturate the decoding queue.
- Default threads to the total number of concurrent allowed decodes, to make sure we can fully saturate the model. 
- Set default minimum to 64.
- Add error handling when queue is out of capacity.