### PR TITLE
Add benchmarks maximum threads config

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -466,7 +466,7 @@ if __name__ == "__main__":
       "--total-mock-requests",
       type=int,
       default=150,
-      help="The maximum number of threads used for request dispatching.",
+      help="The maximum number of mock requests to send for benchmark testing.",
   )
   parser.add_argument("--seed", type=int, default=0)
   parser.add_argument(


### PR DESCRIPTION
- Add `--threads` flag to config the maximum number of threads used for benchmark request dispatching.
  - Default to 110
- Add `--total-mock-requests` to set the number of mock requests to send using mock server for benchmark script testing.
  - Default to 150