### PR TITLE
Support gracefully stopping orchestrator and server

### DIFF
--- a/.github/workflows/UnitTests.yaml
+++ b/.github/workflows/UnitTests.yaml
@@ -70,3 +70,9 @@ jobs:
     - name: Test mock JetStream engine implementation
       run: |
         python -m jetstream.engine.mock_engine_test
+    - name: Test JetStream core orchestrator
+      run: |
+        python -m jetstream.core.orchestrator_test
+    - name: Test JetStream core server library
+      run: |
+        python -m jetstream.core.server_test

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -242,7 +242,7 @@ async def send_request(
     max_tokens: int,
     threads: int,
 ) -> RequestFuncOutput:
-  """Send the request to wiz server."""
+  """Send the request to JetStream server."""
   loop = asyncio.get_running_loop()
   loop.set_default_executor(ThreadPoolExecutor(max_workers=threads))
   request = jetstream_pb2.DecodeRequest(
@@ -406,7 +406,7 @@ def main(args: argparse.Namespace):
     # Save to file
     base_model_id = model_id.split("/")[-1]
     file_name = (
-        f"JetEngine-{args.request_rate}qps-{base_model_id}-{current_dt}.json"
+        f"JetStream-{args.request_rate}qps-{base_model_id}-{current_dt}.json"
     )
     with open(file_name, "w") as outfile:
       json.dump(result_json, outfile)
@@ -433,7 +433,7 @@ if __name__ == "__main__":
       help=(
           "Name of the model. (it's just used to label the benchmark, the model"
           " config is defined in config_lib, and passed as the server config"
-          " flag when we run the wiz-pathways server)"
+          " flag when we run the JetStream server)"
       ),
   )
   parser.add_argument(

--- a/jetstream/core/orchestrator_test.py
+++ b/jetstream/core/orchestrator_test.py
@@ -41,10 +41,10 @@ decoded (these are the ascii chars at those indices which is what the test
 tokenizer returns).
 """
 
-from jetstream.engine import mock_engine
+from absl.testing import absltest
 from jetstream.core import orchestrator
 from jetstream.core.proto import jetstream_pb2
-from absl.testing import absltest
+from jetstream.engine import mock_engine
 
 
 class OrchestratorTest(absltest.TestCase):
@@ -87,12 +87,16 @@ class OrchestratorTest(absltest.TestCase):
     counter = 0
     for token in iterator:
       # Tokens come through as bytes.
-      print('actual output: ' + bytes(token.response[0], encoding='utf-8').decode())
+      print(
+          'actual output: '
+          + bytes(token.response[0], encoding='utf-8').decode()
+      )
       assert (
           bytes(token.response[0], encoding='utf-8').decode()
           == expected_tokens[counter]
       )
       counter += 1
+    driver.stop()
 
 
 if __name__ == '__main__':

--- a/jetstream/core/server_lib.py
+++ b/jetstream/core/server_lib.py
@@ -18,6 +18,7 @@ See implementations/*/sever.py for examples.
 """
 
 from concurrent import futures
+import dataclasses
 import logging
 from typing import Any, Type
 
@@ -31,13 +32,19 @@ from jetstream.core.proto import jetstream_pb2_grpc
 _HOST = '[::]'
 
 
+@dataclasses.dataclass
+class JetStreamServer:
+  driver: orchestrator.Driver
+  server: grpc.Server
+
+
 def run(
     port: int,
     config: Type[config_lib.ServerConfig],
     devices: Any,
     credentials: Any = grpc.insecure_server_credentials(),
     threads: int | None = None,
-) -> grpc.Server:
+) -> JetStreamServer:
   """Runs a server with a specified config.
 
   Args:
@@ -71,7 +78,7 @@ def run(
 
   server.add_secure_port(f'{_HOST}:{port}', credentials)
   server.start()
-  return server
+  return JetStreamServer(driver, server)
 
 
 def get_devices() -> Any:

--- a/jetstream/core/server_test.py
+++ b/jetstream/core/server_test.py
@@ -91,8 +91,7 @@ class ServerTest(parameterized.TestCase):
           == expected_tokens[counter]
       )
       counter += 1
-    server.driver.stop()
-    server.server.stop(grace=None)
+    server.stop()
 
 
 if __name__ == '__main__':

--- a/jetstream/core/server_test.py
+++ b/jetstream/core/server_test.py
@@ -20,14 +20,13 @@ response.
 
 from typing import Any, Type
 
+from absl.testing import absltest, parameterized
 import grpc
-import portpicker
-
 from jetstream.core import config_lib
 from jetstream.core import server_lib
 from jetstream.core.proto import jetstream_pb2
 from jetstream.core.proto import jetstream_pb2_grpc
-from absl.testing import absltest, parameterized
+import portpicker
 
 
 class ServerTest(parameterized.TestCase):
@@ -58,7 +57,7 @@ class ServerTest(parameterized.TestCase):
     print('port: ' + str(port))
     credentials = grpc.local_server_credentials()
 
-    _ = server_lib.run(
+    server = server_lib.run(
         port=port,
         config=config,
         devices=devices,
@@ -83,12 +82,17 @@ class ServerTest(parameterized.TestCase):
     counter = 0
     for token in iterator:
       # Tokens come through as bytes
-      print('actual output: ' + bytes(token.response[0], encoding='utf-8').decode())
+      print(
+          'actual output: '
+          + bytes(token.response[0], encoding='utf-8').decode()
+      )
       assert (
           bytes(token.response[0], encoding='utf-8').decode()
           == expected_tokens[counter]
       )
       counter += 1
+    server.driver.stop()
+    server.server.stop(grace=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Gracefully clean up all threads when stopping the driver
- Add JetStreamServer as the return of `server_lib.run()` (when calling stop(), it handles the threads cleanup)
- Add the orchestrator and server lib unit tests to github action CI