### PR TITLE
Fix starvation with async server and interleaving optimization

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -237,7 +237,8 @@ def calculate_metrics(
 
 async def grpc_async_request(api_url: str, request: Any) -> tuple[list[str], float, float]:
   """Send grpc synchronous request since the current grpc server is sync."""
-  async with grpc.aio.insecure_channel(api_url) as channel:
+  options = [("grpc.keepalive_timeout_ms", 10000)]
+  async with grpc.aio.insecure_channel(api_url, options=options) as channel:
     stub = jetstream_pb2_grpc.OrchestratorStub(channel)
     print("Making request")
     ttft = 0

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -137,7 +137,7 @@ class ActiveRequest:
   # We keep prefill and decode information together in the same object so that
   # there is less indirection about where this return channel is.
   # The return channel returns a list of strings, one per sample for that query.
-  return_channel: async_multifuture.AsyncMultifuture[list[str]]
+  return_channel: async_multifuture.AsyncMultifuture[list[str]] = None
 
   def enqueue_tokens(self, generated_tokens: list[str]):
     """Records information about the step.

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -137,7 +137,7 @@ class ActiveRequest:
   # We keep prefill and decode information together in the same object so that
   # there is less indirection about where this return channel is.
   # The return channel returns a list of strings, one per sample for that query.
-  return_channel: async_multifuture.AsyncMultifuture[list[str]] = None
+  return_channel: async_multifuture.AsyncMultifuture[list[str]]
 
   def enqueue_tokens(self, generated_tokens: list[str]):
     """Records information about the step.

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -472,6 +472,7 @@ class Driver:
 
       max_concurrent_decodes = generate_engine.max_concurrent_decodes
 
+      # TODO: Move insert to prefill thread. 
       # Check if there are any free my_slots. We don't want to block here since
       # we can still generate if we can't insert. We do this in a while loop to
       # insert as many sequences as possible.

--- a/jetstream/core/orchestrator_test.py
+++ b/jetstream/core/orchestrator_test.py
@@ -66,7 +66,7 @@ class OrchestratorTest(absltest.TestCase):
     )
     return driver
 
-  def test_orchestrator(self):
+  async def test_orchestrator(self):
     """Test the multithreaded orchestration."""
     driver = self._setup_driver()
     client = orchestrator.LLMOrchestrator(driver=driver)
@@ -85,7 +85,7 @@ class OrchestratorTest(absltest.TestCase):
     # chr of [266, 332, 415].
     expected_tokens = ['Ċ', 'Ō', 'Ɵ', '']
     counter = 0
-    for token in iterator:
+    async for token in iterator:
       # Tokens come through as bytes.
       print(
           'actual output: '

--- a/jetstream/core/utils/__init__.py
+++ b/jetstream/core/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/jetstream/core/utils/async_multifuture.py
+++ b/jetstream/core/utils/async_multifuture.py
@@ -1,0 +1,87 @@
+import asyncio
+from concurrent import futures
+import threading
+from typing import Generic, TypeVar
+
+ValueType = TypeVar('ValueType')
+
+
+class _Exception:
+  """A class for propagating exceptions through a queue.
+
+  By wrapping them with a custom private class we ensure that any type
+  (including Exception) can be used as a ValueType.
+  """
+
+  def __init__(self, exception: Exception) -> None:
+    self.exception = exception
+
+
+class AsyncMultifuture(Generic[ValueType]):
+  """AsyncMultifuture is like concurrent.futures.Future but supports returning
+
+  multiple results. It provides an unidirectional stream with buffering and
+  exception propagation.
+
+  Supports delivering results to an async Python event loop. Must be
+  constructed
+  inside of the event loop.
+  """
+
+  def __init__(self) -> None:
+    self._cancelled = threading.Event()
+    self._done = threading.Event()
+    self._loop = asyncio.get_running_loop()
+    self._queue = asyncio.Queue[ValueType | _Exception]()
+
+  def cancel(self) -> None:
+    """Cancels the asyncmultifuture."""
+    self._cancelled.set()
+    self.set_exception(futures.CancelledError())
+
+  def cancelled(self) -> bool:
+    """Returns whether the asyncmultifuture has been cancelled."""
+    return self._cancelled.is_set()
+
+  def done(self) -> bool:
+    """AsyncMultifuture is done when it is finalized with close() or set_exception()."""
+    return self._done.is_set()
+
+  def set_exception(self, exception: Exception) -> None:
+    """Stores the given exception in the asyncmultifuture.
+
+    The exception would be delivered after all previously added results are
+    yielded. set_exception can be called multiple times, however subsequent
+    calls will be ignored.
+
+    Args:
+      exception: The exception to set.
+    """
+    self._loop.call_soon_threadsafe(
+        self._queue.put_nowait, _Exception(exception)
+    )
+    self._loop.call_soon_threadsafe(self._done.set)
+
+  def add_result(self, result: ValueType) -> None:
+    """Adds the result to the asyncmultifuture.
+
+    Caller must call .close() once all results are added.
+
+    Args:
+      result: The result to add.
+    """
+    self._loop.call_soon_threadsafe(self._queue.put_nowait, result)
+
+  def close(self) -> None:
+    """Notifies the receiver that no more results would be added."""
+    self.set_exception(StopAsyncIteration())
+
+  def __aiter__(self) -> 'AsyncMultifuture':
+    return self
+
+  async def __anext__(self) -> ValueType:
+    """Returns the next value."""
+    value = await self._queue.get()
+    if isinstance(value, _Exception):
+      raise value.exception
+    return value

--- a/jetstream/core/utils/async_multifuture.py
+++ b/jetstream/core/utils/async_multifuture.py
@@ -1,7 +1,7 @@
 import asyncio
 from concurrent import futures
 import threading
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 ValueType = TypeVar('ValueType')
 
@@ -34,8 +34,10 @@ class AsyncMultifuture(Generic[ValueType]):
     self._loop = asyncio.get_running_loop()
     self._queue = asyncio.Queue[ValueType | _Exception]()
 
-  def cancel(self) -> None:
+  def cancel(self, unused: Any = None) -> None:
     """Cancels the asyncmultifuture."""
+    # Needed for compatibility with grpc.aio.ServicerContext.add_done_callback.
+    del unused
     self._cancelled.set()
     self.set_exception(futures.CancelledError())
 


### PR DESCRIPTION
- Make server async to handle high throughput from client (the number of requests a sync server can handle is limited by server side thread number, since each thread handles a request in blocking manner).
- Add AsyncMultiFuture data structure for the retuern_channel to stream response tokens asynchronously (threadsafe ensures no token drop in async server)
- Using blocking fixed size queue to block and yield threads efficiently
  - blocking for get and put operations for generate and detokenize queue
  - blocking for prefill queue get operation
  - unblocking for prefill queue put operation (unbound queue size to enqueue all requests from client)
- Optimized interleaving prefill, insert, and generate
  - When decode slots are empty, yield to prefill, then insert the prefill results as many as possible to the decode slots
  - When decode slots are full, block insert and prefill, keep decoding and detokenizing until some deocde completes and returns available slot.
  - generate queue size set to 3/1 decode batch size
    - get decode slots saturated fast (larger generate queue size ensures it has enough requests to insert to slots)
    - avoid OOM when both decode slots and generate queue are both saturated (can't set generate queue size too large, otherwise too many prefill results enqueued in generate queue)