### PR TITLE
Add np padded token support

### DIFF
--- a/jetstream/engine/token_utils.py
+++ b/jetstream/engine/token_utils.py
@@ -16,7 +16,7 @@
 
 from bisect import bisect_left
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -57,7 +57,8 @@ def tokenize_and_pad(
     is_bos: bool = True,
     prefill_lengths: Optional[List[int]] = None,
     max_prefill_length: Optional[int] = None,
-) -> Tuple[jax.Array, int]:
+    jax_padding: bool = True,
+) -> Tuple[Union[jax.Array, np.ndarray], int]:
   """Tokenize and pads a string.
 
   Args:
@@ -67,6 +68,7 @@ def tokenize_and_pad(
       as prefill is typically used when beginning sequences.
     prefill_lengths: Buckets to pad the sequence to for static compilation.
     max_prefill_length: Maximum bucket to use.
+    jax_padding: convert to JAX padded tokens if True. 
 
   Returns:
     tokens: Tokenized into integers.
@@ -117,7 +119,9 @@ def tokenize_and_pad(
     padded_tokens = tokens[-padded_length:]
   else:
     padded_tokens = np.pad(tokens, (0, padding))
-  return jnp.array(padded_tokens), true_length
+  if jax_padding:
+    padded_tokens = jnp.array(padded_tokens)
+  return padded_tokens, true_length
 
 
 def process_result_tokens(

--- a/jetstream/engine/token_utils.py
+++ b/jetstream/engine/token_utils.py
@@ -183,7 +183,8 @@ def process_result_tokens(
           break
         else:
           try:
-            token = mix_decode(vocab, tok_id)  # pytype: disable=attribute-error
+            # pytype: disable=attribute-error
+            token = mix_decode(vocab, tok_id)
           except ValueError:
             # This error only occurs when using tests where the vocab range is
             # computed via addition and int->char is computed using chr(). Real

--- a/jetstream/tests/engine/test_token_utils.py
+++ b/jetstream/tests/engine/test_token_utils.py
@@ -117,8 +117,6 @@ class TokenUtilsTest(unittest.TestCase):
       vocab=vocab,
       max_prefill_length=max_prefill_length,
       )
-    print(f"------------- padded_tokens{padded_tokens}")
-    print(f"------------- true_length{true_length}")
     expected_padded_tokens = jnp.array([1, 306, 4658, 278, 6593, 310, 2834, 338,
                                         0, 0, 0, 0, 0, 0, 0, 0])
     expected_true_length = 8
@@ -138,8 +136,6 @@ class TokenUtilsTest(unittest.TestCase):
       max_prefill_length=max_prefill_length,
       jax_padding=False
       )
-    print(f"------------- padded_tokens{padded_tokens}")
-    print(f"------------- true_length{true_length}")
     expected_padded_tokens = np.array([1, 306, 4658, 278, 6593, 310, 2834, 338,
                                         0, 0, 0, 0, 0, 0, 0, 0])
     expected_true_length = 8

--- a/jetstream/tests/engine/test_token_utils.py
+++ b/jetstream/tests/engine/test_token_utils.py
@@ -18,6 +18,9 @@ import os
 import unittest
 from typing import List
 
+import jax
+import jax.numpy as jnp
+import numpy as np
 from sentencepiece import SentencePieceProcessor
 from jetstream.engine import tokenizer_pb2, token_utils
 
@@ -102,6 +105,48 @@ class TokenUtilsTest(unittest.TestCase):
     decode_output = self.sp_tokenizer.decode([n])
     self.assertEqual(mix_output, " `__")
     self.assertEqual(mix_output.lstrip(), decode_output)
+
+  def test_tokenize_and_pad_jax(self):
+    jax.config.update("jax_platform_name", "cpu")
+    self.setup()
+    s = "I believe the meaning of life is"
+    vocab = self.jt_tokenizer.vocab
+    max_prefill_length = 1024
+    padded_tokens, true_length = token_utils.tokenize_and_pad(
+      s=s,
+      vocab=vocab,
+      max_prefill_length=max_prefill_length,
+      )
+    print(f"------------- padded_tokens{padded_tokens}")
+    print(f"------------- true_length{true_length}")
+    expected_padded_tokens = jnp.array([1, 306, 4658, 278, 6593, 310, 2834, 338,
+                                        0, 0, 0, 0, 0, 0, 0, 0])
+    expected_true_length = 8
+    self.assertTrue(
+      jnp.allclose(padded_tokens, expected_padded_tokens, atol=1e-7)
+      )
+    self.assertEqual(true_length, expected_true_length)
+
+  def test_tokenize_and_pad_np(self):
+    self.setup()
+    s = "I believe the meaning of life is"
+    vocab = self.jt_tokenizer.vocab
+    max_prefill_length = 1024
+    padded_tokens, true_length = token_utils.tokenize_and_pad(
+      s=s,
+      vocab=vocab,
+      max_prefill_length=max_prefill_length,
+      jax_padding=False
+      )
+    print(f"------------- padded_tokens{padded_tokens}")
+    print(f"------------- true_length{true_length}")
+    expected_padded_tokens = np.array([1, 306, 4658, 278, 6593, 310, 2834, 338,
+                                        0, 0, 0, 0, 0, 0, 0, 0])
+    expected_true_length = 8
+    self.assertTrue(
+      np.allclose(padded_tokens, expected_padded_tokens, atol=1e-7)
+      )
+    self.assertEqual(true_length, expected_true_length)
 
 
 if __name__ == "__main__":

--- a/jetstream/tests/engine/test_token_utils.py
+++ b/jetstream/tests/engine/test_token_utils.py
@@ -101,7 +101,8 @@ class TokenUtilsTest(unittest.TestCase):
   def test_underscore_in_output(self):
     self.setup()
     n = 21326
-    mix_output = token_utils.mix_decode(vocab=self.jt_tokenizer.vocab, tok_id=n)
+    mix_output = token_utils.mix_decode(
+        vocab=self.jt_tokenizer.vocab, tok_id=n)
     decode_output = self.sp_tokenizer.decode([n])
     self.assertEqual(mix_output, " `__")
     self.assertEqual(mix_output.lstrip(), decode_output)
@@ -113,16 +114,16 @@ class TokenUtilsTest(unittest.TestCase):
     vocab = self.jt_tokenizer.vocab
     max_prefill_length = 1024
     padded_tokens, true_length = token_utils.tokenize_and_pad(
-      s=s,
-      vocab=vocab,
-      max_prefill_length=max_prefill_length,
-      )
+        s=s,
+        vocab=vocab,
+        max_prefill_length=max_prefill_length,
+    )
     expected_padded_tokens = jnp.array([1, 306, 4658, 278, 6593, 310, 2834, 338,
                                         0, 0, 0, 0, 0, 0, 0, 0])
     expected_true_length = 8
     self.assertTrue(
-      jnp.allclose(padded_tokens, expected_padded_tokens, atol=1e-7)
-      )
+        jnp.allclose(padded_tokens, expected_padded_tokens, atol=1e-7)
+    )
     self.assertEqual(true_length, expected_true_length)
 
   def test_tokenize_and_pad_np(self):
@@ -131,17 +132,17 @@ class TokenUtilsTest(unittest.TestCase):
     vocab = self.jt_tokenizer.vocab
     max_prefill_length = 1024
     padded_tokens, true_length = token_utils.tokenize_and_pad(
-      s=s,
-      vocab=vocab,
-      max_prefill_length=max_prefill_length,
-      jax_padding=False
-      )
+        s=s,
+        vocab=vocab,
+        max_prefill_length=max_prefill_length,
+        jax_padding=False
+    )
     expected_padded_tokens = np.array([1, 306, 4658, 278, 6593, 310, 2834, 338,
-                                        0, 0, 0, 0, 0, 0, 0, 0])
+                                       0, 0, 0, 0, 0, 0, 0, 0])
     expected_true_length = 8
     self.assertTrue(
-      np.allclose(padded_tokens, expected_padded_tokens, atol=1e-7)
-      )
+        np.allclose(padded_tokens, expected_padded_tokens, atol=1e-7)
+    )
     self.assertEqual(true_length, expected_true_length)
 
 


### PR DESCRIPTION
Current code only return jax padded token, this PR added np padded token support. It bring two benefits: 

1: Frame framework independent. Not depend on Jax framework 
2: Serialization benefits


The change will not impact current behaviors, existing code can still use Jax padded tokens without any change.  