### PR TITLE
Do nothing for nd array in copy_to_host_async

### DIFF
--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -82,6 +82,9 @@ class ResultTokens(abc.ABC):
 
   def copy_to_host_async(self: "ResultTokens") -> None:
     """Copy to host asynchronously."""
+    # Do nothing for np array
+    if isinstance(self.data, np.ndarray):
+      return
     self.data.copy_to_host_async()
 
   def convert_to_numpy(self: "ResultTokens") -> "ResultTokens":


### PR DESCRIPTION
Do nothing for nd array in copy_to_host_async. Np array is already been synced to host, no need do another copy. It will throw error if we do this operation for np array. 

No impact on current engine implementations as both pytorch and jax path return jax array. 