### PR TITLE
Add jax_padding support driver and server lib

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -201,12 +201,16 @@ class Driver:
   _generate_slots: list[queue.Queue[int]] = []
   _active_requests: list[queue.Queue[tuple[int, ActiveRequest | None]]] = []
 
+  # todo: remove jax_padding after all then engine migrate to np padding
+  _jax_padding = True
+
   def __init__(
       self,
       prefill_engines: Optional[list[engine_api.Engine]] = None,
       generate_engines: Optional[list[engine_api.Engine]] = None,
       prefill_params: Optional[list[Any]] = None,
       generate_params: Optional[list[Any]] = None,
+      jax_padding: bool = True,
   ):
     if prefill_engines is None:
       prefill_engines = []
@@ -282,6 +286,8 @@ class Driver:
         ]
         for idx, engine in enumerate(self._generate_engines)
     ]
+
+    self._jax_padding = jax_padding
 
     # Create all threads
     self._prefill_threads = [
@@ -428,6 +434,7 @@ class Driver:
           vocab,
           is_bos=is_bos,
           max_prefill_length=prefill_engine.max_prefill_length,
+          jax_padding=self._jax_padding,
       )
       # Compute new kv cache for the prefill_text, conditional on
       # history.

--- a/jetstream/core/server_lib.py
+++ b/jetstream/core/server_lib.py
@@ -91,6 +91,7 @@ def run(
     devices: Any,
     credentials: Any = grpc.insecure_server_credentials(),
     threads: int | None = None,
+    jax_padding: bool = True,
 ) -> JetStreamServer:
   """Runs a server with a specified config.
 
@@ -116,6 +117,7 @@ def run(
       generate_engines=engines.generate_engines + engines.interleaved_engines,
       prefill_params=prefill_params + shared_params,
       generate_params=generate_params + shared_params,
+      jax_padding=jax_padding,
   )
   # We default threads to the total number of concurrent allowed decodes,
   # to make sure we can fully saturate the model. Set default minimum to 64.


### PR DESCRIPTION
This pr add  jax_padding support driver and server lib, engine implementation can decide to use jax or np padding. 

We suggest all the engine implementation to use np padding, will remove all the jax_padding after all the engine migrate to np padding. 