### PR TITLE
Add metadata metrics

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -612,9 +612,9 @@ def main(args: argparse.Namespace):
     )
 
     metrics_json = {
-      **metrics_json,
-      **benchmark_result,
-      **json.loads(args.additional_metadata_metrics_to_save)
+        **metrics_json,
+        **benchmark_result,
+        **json.loads(args.additional_metadata_metrics_to_save),
     }
     if args.run_eval:
       metrics_json = {**metrics_json, **eval_json}
@@ -737,9 +737,9 @@ if __name__ == "__main__":
       "--additional-metadata-metrics-to-save",
       type=str,
       help=(
-        "Additional metadata about the workload. Should be a dictionary in the"
-        " form of a string."
-      )
+          "Additional metadata about the workload. Should be a dictionary in the"
+          " form of a string."
+      ),
   )
   parser.add_argument(
       "--priority",

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -614,6 +614,7 @@ def main(args: argparse.Namespace):
     metrics_json["request_rate"] = (
         args.request_rate if args.request_rate < float("inf") else "inf"
     )
+
     metrics_json = {**metrics_json, **benchmark_result}
     if args.run_eval:
       metrics_json = {**metrics_json, **eval_json}

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -604,18 +604,17 @@ def main(args: argparse.Namespace):
     dimensions_json["date"] = current_dt
     dimensions_json["model_id"] = model_id
     dimensions_json["tokenizer_id"] = tokenizer_id
+    dimensions_json = {
+        **dimensions_json,
+        **json.loads(args.additional_metadata_metrics_to_save),
+    }
     metrics_json["num_prompts"] = args.num_prompts
 
     # Traffic
     metrics_json["request_rate"] = (
         args.request_rate if args.request_rate < float("inf") else "inf"
     )
-
-    metrics_json = {
-        **metrics_json,
-        **benchmark_result,
-        **json.loads(args.additional_metadata_metrics_to_save),
-    }
+    metrics_json = {**metrics_json, **benchmark_result}
     if args.run_eval:
       metrics_json = {**metrics_json, **eval_json}
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -737,8 +737,8 @@ if __name__ == "__main__":
       "--additional-metadata-metrics-to-save",
       type=str,
       help=(
-          "Additional metadata about the workload. Should be a dictionary in the"
-          " form of a string."
+          "Additional metadata about the workload. Should be a dictionary in"
+          " the form of a string."
       ),
   )
   parser.add_argument(

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -611,7 +611,11 @@ def main(args: argparse.Namespace):
         args.request_rate if args.request_rate < float("inf") else "inf"
     )
 
-    metrics_json = {**metrics_json, **benchmark_result}
+    metrics_json = {
+      **metrics_json,
+      **benchmark_result,
+      **json.loads(args.additional_metadata_metrics_to_save)
+    }
     if args.run_eval:
       metrics_json = {**metrics_json, **eval_json}
 
@@ -728,6 +732,14 @@ if __name__ == "__main__":
       "--save-result",
       action="store_true",
       help="Specify to save benchmark results to a json file",
+  )
+  parser.add_argument(
+      "--additional-metadata-metrics-to-save",
+      type=str,
+      help=(
+        "Additional metadata about the workload. Should be a dictionary in the"
+        " form of a string."
+      )
   )
   parser.add_argument(
       "--priority",


### PR DESCRIPTION
Add the ability to pass in additional metadata to be added to the metrics json. For example, adding hardware-related metrics (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism) will enable us to drill down performance by how we shard the model.