### PR TITLE
Update JetStream grpc proto to support I/O with text and token ids

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -555,6 +555,7 @@ def main(args: argparse.Namespace):
         args.total_mock_requests
     )  # e.g. [("AB", 2, "AB", 3)]
   else:
+    dataset = []
     if args.dataset == "openorca":
       dataset = load_openorca_dataset_pkl()
     elif args.dataset == "sharegpt":

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -388,10 +388,10 @@ async def grpc_async_request(
     token_list = []
     request_start_time = time.perf_counter()
     response = stub.Decode(request)
-    async for sample_list in response:
+    async for resp in response:
       if ttft == 0:
         ttft = time.perf_counter() - request_start_time
-      token_list.extend(sample_list.response[0].token_ids)
+      token_list.extend(resp.stream_content.samples[0].token_ids)
     latency = time.perf_counter() - request_start_time
     return token_list, ttft, latency
 
@@ -405,9 +405,13 @@ async def send_request(
     priority: int,
 ) -> RequestFuncOutput:
   """Send the request to JetStream server."""
+  # Tokenization on client side following MLPerf standard.
+  token_ids = tokenizer.encode(input_request.prompt)
   request = jetstream_pb2.DecodeRequest(
       session_cache=session_cache,
-      additional_text=input_request.prompt,
+      token_content=jetstream_pb2.DecodeRequest.TokenContent(
+          token_ids=token_ids
+      ),
       priority=priority,
       max_tokens=input_request.output_len,
   )

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -511,6 +511,8 @@ class Driver:
     while self.live:
       # The transfer thread can just sleep until it has work to do.
       new_request = transfer_backlog.get(block=True)
+      if new_request is None:
+        break
       target_idx = min(
           self._generate_backlogs.items(), key=lambda q: q[1].qsize()
       )[0]
@@ -719,10 +721,10 @@ class LLMOrchestrator(jetstream_pb2_grpc.OrchestratorServicer):
     which_content = request.WhichOneof("content")
     content = getattr(request, which_content)
     if which_content == "text_content":
-      return cast(jetstream_pb2.DecodeRequest.TextContent, content).text_content
+      return cast(jetstream_pb2.DecodeRequest.TextContent, content).text
     else:
       return list(
-          cast(jetstream_pb2.DecodeRequest.TokenContent, content).token_content
+          cast(jetstream_pb2.DecodeRequest.TokenContent, content).token_ids
       )
 
   async def Decode(  # pylint: disable=invalid-overridden-method

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -96,6 +96,7 @@ from jetstream.core.utils.return_sample import ReturnSample
 from jetstream.engine import engine_api, tokenizer_api, token_utils
 import numpy as np
 import prometheus_client
+import shortuuid
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)
@@ -247,7 +248,8 @@ class Driver:
     # At first, a request is placed here in order to get prefilled.
     self._prefill_backlog = queue.Queue()
     self._prefill_backlog_size_metric = prometheus_client.Gauge(
-        "jetstream_prefill_backlog_size", "Size of prefill queue"
+        f"jetstream_prefill_backlog_size_{shortuuid.uuid()}",
+        "Size of prefill queue",
     )
 
     # Stage 2

--- a/jetstream/core/proto/jetstream.proto
+++ b/jetstream/core/proto/jetstream.proto
@@ -19,14 +19,13 @@ package jetstream_proto;
 // TODO: Merge this with main JetStream core once we settle on an API.
 
 service Orchestrator {
-  // Generate the next model tokens.
+  // Query LLM to generate text or tokens.
   rpc Decode(DecodeRequest) returns (stream DecodeResponse) {}
 }
+
 message DecodeRequest {
   // Where to load any pre-existing kv cache from.
   string session_cache = 1;
-  // New text from a user or tool.
-  string additional_text = 2;
   int32 priority = 3;
   // The maximum output length of a sequence. It's used in JetStream to control
   // the output/decode length of a sequence. It would not be used in the engine.
@@ -35,12 +34,44 @@ message DecodeRequest {
   // sequence; max_prefill_predict_length is the maximum length of the
   // input/prefill of a sequence.
   int32 max_tokens = 4;
+
+  message TextContent {
+    string text = 1;
+  }
+  message TokenContent {
+    repeated int32 token_ids = 1;
+  }
+
+  // The client can pass the inputs either as a string, in which case the server will
+  // tokenize it, or as tokens, in which case it's the client's responsibility to
+  // ensure they tokenize its input strings with the correct tokenizer.
+  oneof content {
+    TextContent text_content = 5;
+    TokenContent token_content = 6;
+  }
+  reserved 2;
+  // Next ID: 7
 }
+
 message DecodeResponse {
-  // List of responses, one per sample. The list size depends on text generation strategy the engine used.
-  repeated RepeatedTokenIds response = 1;
-}
-message RepeatedTokenIds {
-  // List of token ids, one list per sample. When speculative decoding is disabled, the list size should be 1; When speculative decoding is enabled, the list size should be >= 1.
-  repeated int32 token_ids = 1;
+  // InitialContent supports returning initial one-off response data from the
+  // stream. It's a placeholder for future features such as history cache.
+  message InitialContent {}
+  message StreamContent {
+    message Sample {
+      // The text string decoded from token id(s).
+      string text = 1;
+      // List of token ids, one list per sample. When speculative decoding is disabled, the list size should be 1; When speculative decoding is enabled, the list size should be >= 1.
+      repeated int32 token_ids = 2;
+    }
+    // Supports multiple samples in the StreamContent. The Sample list size depends on text generation strategy the engine used.
+    repeated Sample samples = 1;
+  }
+
+  oneof content {
+    InitialContent initial_content = 2;
+    StreamContent stream_content = 3;
+  }
+  reserved 1;
+  // Next ID: 4
 }

--- a/jetstream/core/proto/jetstream_pb2.py
+++ b/jetstream/core/proto/jetstream_pb2.py
@@ -28,7 +28,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n$jetstream/core/proto/jetstream.proto\x12\x0fjetstream_proto"e\n\rDecodeRequest\x12\x15\n\rsession_cache\x18\x01 \x01(\t\x12\x17\n\x0f\x61\x64\x64itional_text\x18\x02 \x01(\t\x12\x10\n\x08priority\x18\x03 \x01(\x05\x12\x12\n\nmax_tokens\x18\x04 \x01(\x05"E\n\x0e\x44\x65\x63odeResponse\x12\x33\n\x08response\x18\x01 \x03(\x0b\x32!.jetstream_proto.RepeatedTokenIds"%\n\x10RepeatedTokenIds\x12\x11\n\ttoken_ids\x18\x01 \x03(\x05\x32]\n\x0cOrchestrator\x12M\n\x06\x44\x65\x63ode\x12\x1e.jetstream_proto.DecodeRequest\x1a\x1f.jetstream_proto.DecodeResponse"\x00\x30\x01\x62\x06proto3'
+    b'\n$jetstream/core/proto/jetstream.proto\x12\x0fjetstream_proto"\xa7\x02\n\rDecodeRequest\x12\x15\n\rsession_cache\x18\x01 \x01(\t\x12\x10\n\x08priority\x18\x03 \x01(\x05\x12\x12\n\nmax_tokens\x18\x04 \x01(\x05\x12\x42\n\x0ctext_content\x18\x05 \x01(\x0b\x32*.jetstream_proto.DecodeRequest.TextContentH\x00\x12\x44\n\rtoken_content\x18\x06 \x01(\x0b\x32+.jetstream_proto.DecodeRequest.TokenContentH\x00\x1a\x1b\n\x0bTextContent\x12\x0c\n\x04text\x18\x01 \x01(\t\x1a!\n\x0cTokenContent\x12\x11\n\ttoken_ids\x18\x01 \x03(\x05\x42\t\n\x07\x63ontentJ\x04\x08\x02\x10\x03"\xcb\x02\n\x0e\x44\x65\x63odeResponse\x12I\n\x0finitial_content\x18\x02 \x01(\x0b\x32..jetstream_proto.DecodeResponse.InitialContentH\x00\x12G\n\x0estream_content\x18\x03 \x01(\x0b\x32-.jetstream_proto.DecodeResponse.StreamContentH\x00\x1a\x10\n\x0eInitialContent\x1a\x81\x01\n\rStreamContent\x12\x45\n\x07samples\x18\x01 \x03(\x0b\x32\x34.jetstream_proto.DecodeResponse.StreamContent.Sample\x1a)\n\x06Sample\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x11\n\ttoken_ids\x18\x02 \x03(\x05\x42\t\n\x07\x63ontentJ\x04\x08\x01\x10\x02\x32]\n\x0cOrchestrator\x12M\n\x06\x44\x65\x63ode\x12\x1e.jetstream_proto.DecodeRequest\x1a\x1f.jetstream_proto.DecodeResponse"\x00\x30\x01\x62\x06proto3'
 )
 
 _globals = globals()
@@ -38,12 +38,20 @@ _builder.BuildTopDescriptorsAndMessages(
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
-  _globals["_DECODEREQUEST"]._serialized_start = 57
-  _globals["_DECODEREQUEST"]._serialized_end = 158
-  _globals["_DECODERESPONSE"]._serialized_start = 160
-  _globals["_DECODERESPONSE"]._serialized_end = 229
-  _globals["_REPEATEDTOKENIDS"]._serialized_start = 231
-  _globals["_REPEATEDTOKENIDS"]._serialized_end = 268
-  _globals["_ORCHESTRATOR"]._serialized_start = 270
-  _globals["_ORCHESTRATOR"]._serialized_end = 363
+  _globals["_DECODEREQUEST"]._serialized_start = 58
+  _globals["_DECODEREQUEST"]._serialized_end = 353
+  _globals["_DECODEREQUEST_TEXTCONTENT"]._serialized_start = 274
+  _globals["_DECODEREQUEST_TEXTCONTENT"]._serialized_end = 301
+  _globals["_DECODEREQUEST_TOKENCONTENT"]._serialized_start = 303
+  _globals["_DECODEREQUEST_TOKENCONTENT"]._serialized_end = 336
+  _globals["_DECODERESPONSE"]._serialized_start = 356
+  _globals["_DECODERESPONSE"]._serialized_end = 687
+  _globals["_DECODERESPONSE_INITIALCONTENT"]._serialized_start = 522
+  _globals["_DECODERESPONSE_INITIALCONTENT"]._serialized_end = 538
+  _globals["_DECODERESPONSE_STREAMCONTENT"]._serialized_start = 541
+  _globals["_DECODERESPONSE_STREAMCONTENT"]._serialized_end = 670
+  _globals["_DECODERESPONSE_STREAMCONTENT_SAMPLE"]._serialized_start = 629
+  _globals["_DECODERESPONSE_STREAMCONTENT_SAMPLE"]._serialized_end = 670
+  _globals["_ORCHESTRATOR"]._serialized_start = 689
+  _globals["_ORCHESTRATOR"]._serialized_end = 782
 # @@protoc_insertion_point(module_scope)

--- a/jetstream/core/proto/jetstream_pb2_grpc.py
+++ b/jetstream/core/proto/jetstream_pb2_grpc.py
@@ -40,7 +40,7 @@ class OrchestratorServicer(object):
   """TODO: Merge this with main JetStream core once we settle on an API."""
 
   def Decode(self, request, context):
-    """Generate the next model tokens."""
+    """Query LLM to generate text or tokens."""
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
     context.set_details("Method not implemented!")
     raise NotImplementedError("Method not implemented!")

--- a/jetstream/core/utils/return_sample.py
+++ b/jetstream/core/utils/return_sample.py
@@ -1,0 +1,23 @@
+"""ReturnSample is a data structure utility.
+
+It is a data structure that stores the return samples.
+"""
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class ReturnSample:
+  """Both the token ids, their string representation, and other data.
+
+  Used so that the client knows when special token_ids have been returned
+  (i.e.<image_start>) and displays other modalities instead of text, but does
+  not burden the user with maintaining a vocab.
+
+  Attributes:
+    text: Text piece(s) detokenized from token id(s).
+    token_ids: Raw result token id(s).
+  """
+
+  text: list[str]
+  token_ids: list[int]

--- a/jetstream/core/utils/return_sample.py
+++ b/jetstream/core/utils/return_sample.py
@@ -10,10 +10,6 @@ import dataclasses
 class ReturnSample:
   """Both the token ids, their string representation, and other data.
 
-  Used so that the client knows when special token_ids have been returned
-  (i.e.<image_start>) and displays other modalities instead of text, but does
-  not burden the user with maintaining a vocab.
-
   Attributes:
     text: Text piece(s) detokenized from token id(s).
     token_ids: Raw result token id(s).

--- a/jetstream/engine/mock_utils.py
+++ b/jetstream/engine/mock_utils.py
@@ -76,9 +76,9 @@ class TestVocab(Vocabulary):
     results = np.split(ids, ids.shape[0])
     return ["".join([chr(r) for r in list(line[0])]) for line in results]
 
-  def decode(self, ids: np.ndarray):
+  def decode(self, ids: np.ndarray, is_streaming=True):
     """Converts a numpy array into a string."""
-    return self._decode(ids)
+    return is_streaming and self._decode(ids)
 
   def encode_tf(self, s: str) -> np.ndarray:
     """Converts a string into a numpy array."""

--- a/jetstream/engine/token_utils.py
+++ b/jetstream/engine/token_utils.py
@@ -162,6 +162,7 @@ def process_result_tokens(
     slot_max_length: int,
     result_tokens: ResultTokens,
     complete: np.ndarray,
+    is_client_side_tokenization: bool = False,
     debug: bool = False,
 ) -> Tuple[List[ReturnSample], np.ndarray]:
   """Processes a result tokens into a list of strings, handling multiple
@@ -173,6 +174,7 @@ def process_result_tokens(
     result_tokens: The tokens to access by slot.
     complete: Array representing the completion status of each sample in the
       slot.
+    is_client_side_tokenization: Whether to detokenize on client side.
     debug: Whether to log step by step detokenisation.
 
   Returns:
@@ -214,10 +216,11 @@ def process_result_tokens(
           complete[idx] = True
           break
         else:
-          if isinstance(tokenizer, SentencePieceTokenizer):
-            text_so_far.append(tokenizer.decode([tok_id], is_streaming=True))
-          else:
-            text_so_far.append(tokenizer.decode([tok_id]))
+          if not is_client_side_tokenization:
+            if isinstance(tokenizer, SentencePieceTokenizer):
+              text_so_far.append(tokenizer.decode([tok_id], is_streaming=True))
+            else:
+              text_so_far.append(tokenizer.decode([tok_id]))
           tok_id_so_far.append(tok_id)
     return_samples.append(
         ReturnSample(text=text_so_far, token_ids=tok_id_so_far)

--- a/jetstream/engine/tokenizer_api.py
+++ b/jetstream/engine/tokenizer_api.py
@@ -34,7 +34,7 @@ class Tokenizer(abc.ABC):
     """Tokenize a string.
     Args:
         s: String to tokenize.
-        **kwargs: Additional keyword arguments
+        **kwargs: Additional keyword arguments.
     Returns:
         tokens: Tokenized into integers.
         true_length: Actual length of the non-padded sequence
@@ -42,33 +42,11 @@ class Tokenizer(abc.ABC):
     """
 
   @abc.abstractmethod
-  def decode(
-      self,
-      slot: int,
-      slot_max_length: int,
-      result_tokens: ResultTokens,
-      complete: np.ndarray,
-      **kwargs,
-  ) -> Tuple[list[list[int]], np.ndarray]:
-    """Processes a result tokens into a list of token ids, handling multiple
-    samples.
-    Args:
-      slot: The slot at which to draw tokens from.
-      slot_max_length: Max length for a sample in the slot.
-      result_tokens: The tokens to access by slot.
-      complete: Array representing the completion status of each sample in the
-        slot.
-      **kwards: Additional keyword arguments.
-    Returns:
-      sample_return: List of token_ids, one per sample.
-      complete: Updated complete.
-    """
-
-  @abc.abstractmethod
-  def decode_str(self, token_ids: list[int]) -> str:
+  def decode(self, token_ids: list[int], **kwargs) -> str:
     """Processess input token ids to generate a string.
     Args:
       token_ids: List of token ids.
+      **kwargs: Additional keyword arguments.
     Returns:
       str: String generated from the token ids.
     """

--- a/jetstream/tests/engine/test_utils.py
+++ b/jetstream/tests/engine/test_utils.py
@@ -57,30 +57,32 @@ class UtilsTest(absltest.TestCase):
     )
     vocab = mock_utils.TestVocab()
     per_channel, complete = token_utils.process_result_tokens(
+        tokenizer=vocab,
         slot=0,
         slot_max_length=4,
         result_tokens=result_tokens,
-        eos_id=vocab.eos_id,
-        pad_id=vocab.pad_id,
         complete=mock_complete,
     )
     np.testing.assert_equal(complete, np.array([1, 0]))
 
-    text_output = [mock_utils.TestVocab().decode(row) for row in per_channel]
+    text_output = [
+        mock_utils.TestVocab().decode(row.token_ids) for row in per_channel
+    ]
     assert not text_output[0]  # i.e. == '', because of the pad.
     assert text_output[1] == "AD"
     mock_complete = np.zeros(
         (mock_tokens.shape[0] // samples_per_slot), dtype=np.int32
     )
     per_channel, complete = token_utils.process_result_tokens(
+        tokenizer=vocab,
         slot=1,
         slot_max_length=4,
         result_tokens=result_tokens,
-        eos_id=vocab.eos_id,
-        pad_id=vocab.pad_id,
         complete=mock_complete,
     )
-    text_output = [mock_utils.TestVocab().decode(row) for row in per_channel]
+    text_output = [
+        mock_utils.TestVocab().decode(row.token_ids) for row in per_channel
+    ]
     assert text_output[0] == "T3"
     assert text_output[1] == "A"  # second token is padded.
     np.testing.assert_equal(complete, np.array([0, 1]))

--- a/jetstream/tests/engine/test_utils.py
+++ b/jetstream/tests/engine/test_utils.py
@@ -62,6 +62,7 @@ class UtilsTest(absltest.TestCase):
         slot_max_length=4,
         result_tokens=result_tokens,
         complete=mock_complete,
+        is_client_side_tokenization=False,
     )
     np.testing.assert_equal(complete, np.array([1, 0]))
 
@@ -79,6 +80,7 @@ class UtilsTest(absltest.TestCase):
         slot_max_length=4,
         result_tokens=result_tokens,
         complete=mock_complete,
+        is_client_side_tokenization=False,
     )
     text_output = [
         mock_utils.TestVocab().decode(row.token_ids) for row in per_channel

--- a/jetstream/tools/load_tester.py
+++ b/jetstream/tools/load_tester.py
@@ -38,11 +38,11 @@ def collect_tokens(
     response: Iterator[jetstream_pb2.DecodeResponse], print_interim: bool
 ) -> list[str]:
   tokens = []
-  for token_list in response:
-    tok = token_list.response[0]
+  for resp in response:
+    text_pieces = resp.stream_content.samples[0].text
     if print_interim:
-      print(tok, end="", flush=True)
-    tokens.append(tok)
+      print(text_pieces, end="", flush=True)
+    tokens.extend(text_pieces)
   return tokens
 
 
@@ -56,7 +56,7 @@ def api_call(
   """Sends a request to server and returns text."""
   request = jetstream_pb2.DecodeRequest(
       session_cache=session_cache,
-      additional_text=text,
+      text_content=jetstream_pb2.DecodeRequest.TextContent(text=text),
       priority=1,
       max_tokens=max_tokens,
   )

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ seqio
 tiktoken
 blobfile
 parameterized
+shortuuid

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ pytest
 seqio
 tiktoken
 blobfile
+parameterized

--- a/requirements.txt
+++ b/requirements.txt
@@ -238,6 +238,8 @@ sentencepiece==0.1.99
     # via seqio
 seqio==0.0.19
     # via -r requirements.in
+shortuuid==1.0.13
+    # via -r requirements.in
 six==1.16.0
     # via
     #   astunparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,6 +173,8 @@ packaging==23.2
     #   pytest
     #   seqio
     #   tensorflow
+parameterized==0.9.0
+    # via -r requirements.in
 pluggy==1.4.0
     # via pytest
 portpicker==1.6.0


### PR DESCRIPTION
- Update gprc proto to support
  - Request: token id or text (one of).
  - Response: token id, text or both of them.
  - When input token id, return only token ids. (client tokenization (MLPerf) mode)
  - When input text, return both text and token ids.
- Refactored detokenization handling and Tokenizer API to decouple the logics.
- Added complete support for SentencePiece tokenizer streaming decoding (ensured output text correctness).
- Added and update unit tests for token utils, orchestrator, and server.
- Benchmark script client-side tokenization is enabled.