### PR TITLE
Unit test coverage cleanup

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -80,4 +80,4 @@ jobs:
         coverage run -m unittest -v
     - name: Create test coverage report
       run: |
-        coverage report -m --omit="jetstream/core/proto/*,jetstream/engine/tokenizer_pb2.py,jetstream/third_party/*"
+        coverage report -m --omit="jetstream/core/proto/*,jetstream/engine/tokenizer_pb2.py,jetstream/third_party/*" --fail-under=96

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -80,4 +80,4 @@ jobs:
         coverage run -m unittest -v
     - name: Create test coverage report
       run: |
-        coverage report -m
+        coverage report -m --omit="jetstream/core/proto/*,jetstream/engine/tokenizer_pb2.py,jetstream/third_party/*"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Unit Tests](https://github.com/google/JetStream/actions/workflows/unit_tests.yaml/badge.svg)](https://github.com/google/JetStream/actions/workflows/unit_tests.yaml)
+[![Unit Tests](https://github.com/google/JetStream/actions/workflows/unit_tests.yaml/badge.svg?branch=main)](https://github.com/google/JetStream/actions/workflows/unit_tests.yaml?query=branch:main)
 [![PyPI version](https://badge.fury.io/py/google-jetstream.svg)](https://badge.fury.io/py/google-jetstream)
 [![PyPi downloads](https://img.shields.io/pypi/dm/google-jetstream?style=flat-square&logo=pypi&logoColor=white)](https://pypi.org/project/google-jetstream/)
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ python -m jetstream.tools.load_tester
 ### Test core modules
 ```
 # Test JetStream core orchestrator
-python -m jetstream.tests.core.test_orchestrator
+python -m unittest -v jetstream.tests.core.test_orchestrator
 
 # Test JetStream core server library
-python -m jetstream.tests.core.test_server
+python -m unittest -v jetstream.tests.core.test_server
 
 # Test mock JetStream engine implementation
-python -m jetstream.tests.engine.test_mock_engine
+python -m unittest -v jetstream.tests.engine.test_mock_engine
 
 # Test mock JetStream token utils
-python -m jetstream.tests.engine.test_utils
+python -m unittest -v jetstream.tests.engine.test_token_utils
+python -m unittest -v jetstream.tests.engine.test_utils
 
 ```

--- a/jetstream/core/config_lib.py
+++ b/jetstream/core/config_lib.py
@@ -38,12 +38,6 @@ class ServerConfig:
   generate_engine_create_fns: Tuple[CreateEngineFn, ...] = ()
   interleaved_engine_create_fns: Tuple[CreateEngineFn, ...] = ()
 
-  def get_slices_to_launch(self: "ServerConfig") -> str:
-    """Used when launching this config via xm config."""
-    return ",".join(
-        self.prefill_slices + self.generate_slices + self.interleaved_slices
-    )
-
 
 @dataclasses.dataclass
 class InstantiatedEngines:

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -85,7 +85,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import Any, AsyncIterator, Optional, Tuple, Union, cast
+from typing import Any, AsyncIterator, Optional, Tuple, cast
 
 import grpc
 import jax
@@ -434,13 +434,6 @@ class Driver:
     self._prefill_backlog.put(request, block=False)
     self._prefill_backlog_size_metric.set(self._prefill_backlog.qsize())
 
-  def _load_cache_history(self, path: str) -> Union[None, Any]:
-    """Loads previous kv cache for a longer conversation."""
-    if path:
-      raise NotImplementedError
-    else:
-      return None
-
   def _process_prefill_content(
       self,
       request: ActiveRequest,
@@ -744,6 +737,60 @@ class LLMOrchestrator(jetstream_pb2_grpc.OrchestratorServicer):
           True,
       )
 
+  def process_client_side_tokenization_response(self, response: Any):
+    samples = []
+    for sample in response:
+      samples.append(
+          jetstream_pb2.DecodeResponse.StreamContent.Sample(
+              token_ids=sample.token_ids,
+          )
+      )
+    return jetstream_pb2.DecodeResponse(
+        stream_content=jetstream_pb2.DecodeResponse.StreamContent(
+            samples=samples
+        )
+    )
+
+  def should_buffer_response(self, response: Any) -> bool:
+    for item in response:
+      if item.text and token_utils.is_byte_token(item.text[-1]):
+        # If any sample ends in bytes, this means we might still need to
+        # decode more bytes to compose the string.
+        return True
+
+  def process_server_side_tokenization_response(
+      self, response: Any, buffered_response_list
+  ):
+    # Flush the buffered responses to each sample of current response.
+    current_response_with_flushed_buffer = list(
+        zip(*buffered_response_list, response)
+    )
+    # Empty buffer: [[s0_cur], [s1_cur], ...]
+    # Has buffer:
+    # [[s0_b0, s0_b1, ..., s0_cur], [s1_b0, s1_b1, ..., s1_cur], ...]
+    current_response_with_flushed_buffer = cast(
+        list[list[ReturnSample]], current_response_with_flushed_buffer
+    )
+    # Form correct sample(s) and return as StreamContent for this iteration.
+    samples = []
+    for sample in current_response_with_flushed_buffer:
+      text = []
+      token_ids = []
+      for resp in sample:
+        text.extend(resp.text)
+        token_ids.extend(resp.token_ids)
+      samples.append(
+          jetstream_pb2.DecodeResponse.StreamContent.Sample(
+              text=token_utils.text_tokens_to_str(text),
+              token_ids=token_ids,
+          )
+      )
+    return jetstream_pb2.DecodeResponse(
+        stream_content=jetstream_pb2.DecodeResponse.StreamContent(
+            samples=samples
+        )
+    )
+
   async def Decode(  # pylint: disable=invalid-overridden-method
       self,
       request: jetstream_pb2.DecodeRequest,
@@ -795,70 +842,24 @@ class LLMOrchestrator(jetstream_pb2_grpc.OrchestratorServicer):
     # The DecodeResponse stream should consume all generated tokens in
     # return_channel when complete signal is received (AsyncMultifuture
     # promises this).
-    if is_client_side_tokenization:
-      # If is_client_side_tokenization, the client should request with token
-      # ids, and the JetStream server will return token ids as response.
-      # The client should take care of tokenization and detokenization.
-      async for response in active_request.return_channel:
-        response = cast(list[ReturnSample], response)
-        samples = []
-        for sample in response:
-          samples.append(
-              jetstream_pb2.DecodeResponse.StreamContent.Sample(
-                  token_ids=sample.token_ids,
-              )
-          )
-        yield jetstream_pb2.DecodeResponse(
-            stream_content=jetstream_pb2.DecodeResponse.StreamContent(
-                samples=samples
-            )
-        )
-    else:
-      # Buffer response mechanism is used to handle streaming
-      # detokenization with special character (For some edge cases with
-      # SentencePiece tokenizer, it requires to decode a complete sequence
-      # instead of a single token).
-      buffered_response_list = []
-      async for response in active_request.return_channel:
-        response = cast(list[ReturnSample], response)
-        buffered = False
-        for item in response:
-          if item.text and token_utils.is_byte_token(item.text[-1]):
-            # If any sample ends in bytes, this means we might still need to
-            # decode more bytes to compose the string.
-            buffered_response_list.append(response)
-            buffered = True
-            break
-        if buffered:
+    buffered_response_list = []
+    async for response in active_request.return_channel:
+      response = cast(list[ReturnSample], response)
+      if is_client_side_tokenization:
+        # If is_client_side_tokenization, the client should request with token
+        # ids, and the JetStream server will return token ids as response.
+        # The client should take care of tokenization and detokenization.
+        yield self.process_client_side_tokenization_response(response)
+      else:
+        # Buffer response mechanism is used to handle streaming
+        # detokenization with special character (For some edge cases with
+        # SentencePiece tokenizer, it requires to decode a complete sequence
+        # instead of a single token).
+        if self.should_buffer_response(response):
+          buffered_response_list.append(response)
           continue
-        # Flush the buffered responses to each sample of current response.
-        current_response_with_flushed_buffer = list(
-            zip(*buffered_response_list, response)
-        )
-        # Empty buffer: [[s0_cur], [s1_cur], ...]
-        # Has buffer:
-        # [[s0_b0, s0_b1, ..., s0_cur], [s1_b0, s1_b1, ..., s1_cur], ...]
-        current_response_with_flushed_buffer = cast(
-            list[list[ReturnSample]], current_response_with_flushed_buffer
+        yield self.process_server_side_tokenization_response(
+            response, buffered_response_list
         )
         # Reset buffer after flushed.
         buffered_response_list = []
-        # Form correct sample(s) and return as StreamContent for this iteration.
-        samples = []
-        for sample in current_response_with_flushed_buffer:
-          text = []
-          token_ids = []
-          for resp in sample:
-            text.extend(resp.text)
-            token_ids.extend(resp.token_ids)
-          samples.append(
-              jetstream_pb2.DecodeResponse.StreamContent.Sample(
-                  text=token_utils.text_tokens_to_str(text),
-                  token_ids=token_ids,
-              )
-          )
-        yield jetstream_pb2.DecodeResponse(
-            stream_content=jetstream_pb2.DecodeResponse.StreamContent(
-                samples=samples
-            )
-        )

--- a/jetstream/tests/core/test_config_lib.py
+++ b/jetstream/tests/core/test_config_lib.py
@@ -14,22 +14,14 @@
 
 """Unit test for config_lib.py."""
 
-from absl.testing import absltest, parameterized
+import unittest
+from parameterized import parameterized
 from jetstream.core import config_lib
 
 
-class TestConfigLib(parameterized.TestCase):
+class TestConfigLib(unittest.TestCase):
 
-  @parameterized.parameters(
-      ("tpu=8", 8),
-      ("v5e-8", 8),
-      ("v5e=4", 4),
-      ("v4-8", 4),
-  )
+  @parameterized.expand([("tpu=8", 8), ("v5e-8", 8), ("v5e=4", 4), ("v4-8", 4)])
   def test_slice_to_num_chips(self, accelerator_slice, expected_num_devices):
     got = config_lib.slice_to_num_chips(accelerator_slice)
     self.assertEqual(got, expected_num_devices)
-
-
-if __name__ == "__main__":
-  absltest.main()

--- a/jetstream/tests/core/test_config_lib.py
+++ b/jetstream/tests/core/test_config_lib.py
@@ -25,3 +25,7 @@ class TestConfigLib(unittest.TestCase):
   def test_slice_to_num_chips(self, accelerator_slice, expected_num_devices):
     got = config_lib.slice_to_num_chips(accelerator_slice)
     self.assertEqual(got, expected_num_devices)
+
+  def test_get_engines_invalid(self):
+    with self.assertRaises(ValueError):
+      config_lib.get_engines(config_lib.InterleavedCPUTestServer, [])

--- a/jetstream/tests/core/test_orchestrator.py
+++ b/jetstream/tests/core/test_orchestrator.py
@@ -130,7 +130,3 @@ class OrchestratorTest(unittest.IsolatedAsyncioTestCase):
       counter += 1
     driver.stop()
     print("Orchestrator driver stopped.")
-
-
-if __name__ == "__main__":
-  unittest.main()

--- a/jetstream/tests/core/test_orchestrator.py
+++ b/jetstream/tests/core/test_orchestrator.py
@@ -44,6 +44,7 @@ tokenizer returns).
 import unittest
 from jetstream.core import orchestrator
 from jetstream.core.proto import jetstream_pb2
+from jetstream.core.utils.return_sample import ReturnSample
 from jetstream.engine import mock_engine
 
 
@@ -128,5 +129,16 @@ class OrchestratorTest(unittest.IsolatedAsyncioTestCase):
       assert output_text == expected_text[counter]
       assert output_token_id == expected_token_ids[counter]
       counter += 1
+    driver.stop()
+    print("Orchestrator driver stopped.")
+
+  def test_should_buffer_response(self):
+    driver = self._setup_driver_interleaved_mode()
+    client = orchestrator.LLMOrchestrator(driver=driver)
+    self.assertTrue(
+        client.should_buffer_response(
+            [ReturnSample(text=["<0xAB>"], token_ids=[13])]
+        )
+    )
     driver.stop()
     print("Orchestrator driver stopped.")

--- a/jetstream/tests/core/test_server.py
+++ b/jetstream/tests/core/test_server.py
@@ -95,3 +95,6 @@ class ServerTest(unittest.IsolatedAsyncioTestCase):
         assert output_token_id == expected_token_ids[counter]
         counter += 1
       server.stop()
+
+  def test_get_devices(self):
+    assert len(server_lib.get_devices()) == 1

--- a/jetstream/tests/core/test_server.py
+++ b/jetstream/tests/core/test_server.py
@@ -95,7 +95,3 @@ class ServerTest(unittest.IsolatedAsyncioTestCase):
         assert output_token_id == expected_token_ids[counter]
         counter += 1
       server.stop()
-
-
-if __name__ == "__main__":
-  unittest.main()

--- a/jetstream/tests/engine/test_mock_engine.py
+++ b/jetstream/tests/engine/test_mock_engine.py
@@ -30,15 +30,15 @@ If we then insert that and run three generation steps, we should see
 I.e. ['Ċ', 'Ə', 'ɖ'] when converted back with chr()
 """
 
+import unittest
 import jax.numpy as jnp
 import numpy as np
 
 from jetstream.engine import mock_engine
 from jetstream.engine import token_utils
-from absl.testing import absltest
 
 
-class EngineTest(absltest.TestCase):
+class EngineTest(unittest.TestCase):
 
   def _setup(self):
     """Initialises a test engine."""
@@ -128,7 +128,3 @@ class EngineTest(absltest.TestCase):
     token_data = sampled_tokens.get_result_at_slot(slot)
     tok = token_data.tokens
     assert tokenizer.IdToPiece(int(tok.item())) == "ɖ"
-
-
-if __name__ == "__main__":
-  absltest.main()

--- a/jetstream/tests/engine/test_token_utils.py
+++ b/jetstream/tests/engine/test_token_utils.py
@@ -559,7 +559,3 @@ class TokenUtilsTest(unittest.TestCase):
         )
         == "你好�\n�hello"
     )
-
-
-if __name__ == "__main__":
-  unittest.main()

--- a/jetstream/tests/engine/test_utils.py
+++ b/jetstream/tests/engine/test_utils.py
@@ -88,3 +88,22 @@ class UtilsTest(unittest.TestCase):
     assert text_output[0] == "T3"
     assert text_output[1] == "A"  # second token is padded.
     np.testing.assert_equal(complete, np.array([0, 1]))
+
+  def test_mock_utils(self):
+    vocab = mock_utils.TestVocab()
+    # test encode()
+    with self.assertRaises(NotImplementedError):
+      vocab.encode("AB")
+    # test encode_tf()
+    token_ids = vocab.encode_tf("AB")
+    np.testing.assert_equal(token_ids, np.array([65, 66]))
+    # test decode()
+    ids = np.array([ord("A")])
+    expected = "A"
+    result = vocab.decode(ids)
+    self.assertEqual(result, expected)
+    # test decode_tf()
+    ids = np.array([[ord("A")]])
+    expected = ["A"]
+    result_tf = vocab.decode_tf(ids)
+    self.assertEqual(result_tf, expected)

--- a/jetstream/tests/engine/test_utils.py
+++ b/jetstream/tests/engine/test_utils.py
@@ -15,13 +15,13 @@
 """Tests functionality of the token processing utils using mock engine vocab."""
 
 import numpy as np
+import unittest
 from jetstream.engine import engine_api
 from jetstream.engine import mock_utils
 from jetstream.engine import token_utils
-from absl.testing import absltest
 
 
-class UtilsTest(absltest.TestCase):
+class UtilsTest(unittest.TestCase):
 
   def test_speculations_with_multi_sample_slots(self, samples_per_slot=2):
     # [4, 1]
@@ -88,7 +88,3 @@ class UtilsTest(absltest.TestCase):
     assert text_output[0] == "T3"
     assert text_output[1] == "A"  # second token is padded.
     np.testing.assert_equal(complete, np.array([0, 1]))
-
-
-if __name__ == "__main__":
-  absltest.main()


### PR DESCRIPTION
- Increase unit test coverage from 90% to 96%
- Enable test coverage threshold (>=96%) in CI.
- Refactor Orchestrator Driver Decode response handling.
- Remove unused code.