### PR TITLE
Update benchmark script to easily test llama-3

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,6 +29,19 @@ python benchmark_serving.py \
 
 ```
 
+### Run Benchmark for Llama 3
+
+```
+python benchmark_serving.py \
+--tokenizer <llama3 tokenizer path> \
+--num-prompts 10  \
+--dataset sharegpt \
+--dataset-path ~/data/ShareGPT_V3_unfiltered_cleaned_split.json \
+--max-output-length 1024 \
+--model llama-3
+
+```
+
 ### Save request outputs in Benchmark
 
 Please use `--save-request-outputs` flag to save predictions to a file.

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -131,7 +131,7 @@ def get_tokenizer(model_id: str, tokenizer_name: str) -> Any:
   """Return a tokenizer or a tokenizer placholder."""
   if tokenizer_name == "test":
     return "test"
-  elif model_id == 'llama-3':
+  elif model_id == "llama-3":
     # Llama 3 uses a tiktoken tokenizer.
     return llama3_tokenizer.Tokenizer(tokenizer_name)
   else:

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -71,6 +71,7 @@ import grpc
 from jetstream.core.proto import jetstream_pb2
 from jetstream.core.proto import jetstream_pb2_grpc
 from jetstream.engine.token_utils import load_vocab
+from jetstream.third_party.llama3 import llama3_tokenizer
 import numpy as np
 from tqdm.asyncio import tqdm  # pytype: disable=pyi-error
 from eval_accuracy import eval_accuracy
@@ -126,10 +127,13 @@ class RequestFuncOutput:
     }
 
 
-def get_tokenizer(tokenizer_name: str) -> Any:
+def get_tokenizer(model_id: str, tokenizer_name: str) -> Any:
   """Return a tokenizer or a tokenizer placholder."""
   if tokenizer_name == "test":
     return "test"
+  elif model_id == 'llama-3':
+    # Llama 3 uses a tiktoken tokenizer.
+    return llama3_tokenizer.Tokenizer(tokenizer_name)
   else:
     # Use JetStream tokenizer util. It's using the sentencepiece wrapper in
     # seqio library.
@@ -185,18 +189,14 @@ def tokenize_dataset(
   prompts = []
   outputs = []
   indices = []
-
+  prompt_token_ids = []
+  outputs_token_ids = []
   for prompt, output, idx in dataset:
     prompts.append(prompt)
     outputs.append(output)
     indices.append(idx)
-
-  prompt_token_ids = tokenizer.encode(
-      prompts
-  )  # adjust this code based on tokenizer method
-  outputs_token_ids = tokenizer.encode(
-      outputs
-  )  # adjust this code based on tokenizer method
+    prompt_token_ids.append(tokenizer.encode(prompt))
+    outputs_token_ids.append(tokenizer.encode(output))
 
   tokenized_dataset = []
   for i in range(n):
@@ -535,7 +535,7 @@ def main(args: argparse.Namespace):
 
   api_url = f"{args.server}:{args.port}"
 
-  tokenizer = get_tokenizer(tokenizer_id)
+  tokenizer = get_tokenizer(model_id, tokenizer_id)
   if tokenizer == "test" or args.dataset == "test":
     input_requests = mock_requests(
         args.total_mock_requests
@@ -661,9 +661,10 @@ if __name__ == "__main__":
       type=str,
       default="no_model",
       help=(
-          "Name of the model. (it's just used to label the benchmark, the model"
-          " config is defined in config_lib, and passed as the server config"
-          " flag when we run the JetStream server)"
+          "Name of the model like llama-2, llama-3, gemma. (it's just used to"
+          " label the benchmark, pick the tokenizer, the model config is"
+          " defined in config_lib, and passed as the server config flag when"
+          " we run the JetStream server)"
       ),
   )
   parser.add_argument(

--- a/jetstream/third_party/llama3/llama3_tokenizer.py
+++ b/jetstream/third_party/llama3/llama3_tokenizer.py
@@ -107,8 +107,8 @@ class Tokenizer:
       self,
       s: str,
       *,
-      bos: bool,
-      eos: bool,
+      bos: bool = False,
+      eos: bool = False,
       allowed_special: Union[Literal["all"], AbstractSet[str]] | None = None,
       disallowed_special: Union[Literal["all"], Collection[str]] = (),
   ) -> List[int]:


### PR DESCRIPTION
Tested on llama3 and llama2
LLAMA 3:
Successful requests: 1780
Benchmark duration: 294.101467 s
Total input tokens: 214914
Total generated tokens: 415416
Request throughput: 6.05 requests/s
Input token throughput: 730.75 tokens/s
Output token throughput: 1412.49 tokens/s
Mean TTFT: 114960.78 ms
Median TTFT: 115488.55 ms
P99 TTFT: 243659.12 ms
Mean TPOT: 4429.77 ms
Median TPOT: 611.68 ms
P99 TPOT: 132710.43 ms


LLAMA 2:
Successful requests: 100
Benchmark duration: 29.060651 s
Total input tokens: 12503
Total generated tokens: 30175
Request throughput: 3.44 requests/s
Input token throughput: 430.24 tokens/s
Output token throughput: 1038.35 tokens/s
Mean TTFT: 1274.09 ms
Median TTFT: 1273.70 ms
P99 TTFT: 1276.27 ms
Mean TPOT: 58.04 ms
Median TPOT: 34.34 ms
P99 TPOT: 358.49 ms
