### PR TITLE
Add JetStream E2E test CI

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Details for GCP Service Account Key setup: https://github.com/google-github-actions/auth?tab=readme-ov-file#sake
+
 name: E2E Tests
 
 on:
@@ -32,8 +34,7 @@ jobs:
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          credentials_json: '${{ secrets.GOOGLE_SA_KEY }}'
 
       - name: Setup gcloud
         uses: 'google-github-actions/setup-gcloud@v2'

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  run_e2e_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: GCP SA auth
+        id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run E2E tests on ml-automation-solutions platform
+        run: |
+          gcloud composer environments run ml-automation-solutions \
+            --project=cloud-ml-auto-solutions \
+            --location=us-central1 dags trigger \
+            -- \
+            jetstream_e2e_inference


### PR DESCRIPTION
- Added CI to trigger JetStream E2E test for each main branch commit (each PR merged to main branch)
   - https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/290 
- Use a GCP Service Account to execute the command in CI.
   - Added Service Account Key `secrets.GOOGLE_SA_KEY` in the current Github repo
   - https://github.com/google-github-actions/auth?tab=readme-ov-file#sake

Manual trigger E2E test result: https://46c56b977f2b44158661f1ef150119c7-dot-us-central1.composer.googleusercontent.com/dags/jetstream_e2e_inference/grid
- Test Duration: 18 mins