### PR TITLE
Change `jetstream_slots_available_percentage` to `jetstream_slots_used_percentage`

### DIFF
--- a/docs/observability-prometheus-metrics-in-jetstream-server.md
+++ b/docs/observability-prometheus-metrics-in-jetstream-server.md
@@ -45,7 +45,7 @@ Now that we configured `prometheus_port=9090` above, we can observe various Jets
 # HELP jetstream_prefill_backlog_size Size of prefill queue
 # TYPE jetstream_prefill_backlog_size gauge
 jetstream_prefill_backlog_size{id="SOME-HOSTNAME-HERE>"} 0.0
-# HELP jetstream_slots_available_percentage The percentage of available slots in decode batch
-# TYPE jetstream_slots_available_percentage gauge
-jetstream_slots_available_percentage{id="<SOME-HOSTNAME-HERE>",idx="0"} 0.96875
+# HELP jetstream_slots_used_percentage The percentage of decode slots currently being used
+# TYPE jetstream_slots_used_percentage gauge
+jetstream_slots_used_percentage{id="<SOME-HOSTNAME-HERE>",idx="0"} 0.96875
 ```

--- a/docs/observability-prometheus-metrics-in-jetstream-server.md
+++ b/docs/observability-prometheus-metrics-in-jetstream-server.md
@@ -47,5 +47,5 @@ Now that we configured `prometheus_port=9090` above, we can observe various Jets
 jetstream_prefill_backlog_size{id="SOME-HOSTNAME-HERE>"} 0.0
 # HELP jetstream_slots_used_percentage The percentage of decode slots currently being used
 # TYPE jetstream_slots_used_percentage gauge
-jetstream_slots_used_percentage{id="<SOME-HOSTNAME-HERE>",idx="0"} 0.96875
+jetstream_slots_used_percentage{id="<SOME-HOSTNAME-HERE>",idx="0"} 0.04166666666666663
 ```

--- a/jetstream/core/metrics/prometheus.py
+++ b/jetstream/core/metrics/prometheus.py
@@ -35,14 +35,14 @@ class JetstreamMetricsCollector:
       documentation="Size of prefill queue",
       labelnames=["id"],
   )
-  _slots_available_percentage = Gauge(
-      name="jetstream_slots_available_percentage",
-      documentation="The percentage of available slots in decode batch",
+  _slots_used_percentage = Gauge(
+      name="jetstream_slots_used_percentage",
+      documentation="The percentage of decode slots currently being used",
       labelnames=["id", "idx"],
   )
 
   def get_prefill_backlog_metric(self):
     return self._prefill_backlog.labels(id=self._id)
 
-  def get_slots_available_percentage_metric(self, idx: int):
-    return self._slots_available_percentage.labels(id=self._id, idx=idx)
+  def get_slots_used_percentage_metric(self, idx: int):
+    return self._slots_used_percentage.labels(id=self._id, idx=idx)

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -599,7 +599,9 @@ class Driver:
       if self._metrics_collector:
         self._metrics_collector.get_slots_used_percentage_metric(
             idx
-        ).set_function(lambda: float(1 - (my_slots.qsize() / max_concurrent_decodes)))
+        ).set_function(
+            lambda: float(1 - (my_slots.qsize() / max_concurrent_decodes))
+        )
 
       # Check if there are any free my_slots. We don't want to block here since
       # we can still generate if we can't insert. We do this in a while loop to

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -597,9 +597,9 @@ class Driver:
       max_concurrent_decodes = generate_engine.max_concurrent_decodes
 
       if self._metrics_collector:
-        self._metrics_collector.get_slots_available_percentage_metric(
+        self._metrics_collector.get_slots_used_percentage_metric(
             idx
-        ).set_function(lambda: float(my_slots.qsize() / max_concurrent_decodes))
+        ).set_function(lambda: float(1 - (my_slots.qsize() / max_concurrent_decodes)))
 
       # Check if there are any free my_slots. We don't want to block here since
       # we can still generate if we can't insert. We do this in a while loop to


### PR DESCRIPTION
HPA doesn't allow scaling up as a metric decreases. Our jetstream_slots_available_percentage metric has to be changed to jetstream_slots_used_percentage. This is also in line with other inference server metrics like `tgi_batch_current_size` and `nv_trt_llm_inflight_batcher_metrics`
 