### PR TITLE
Fix benchmark script for saving benchmark result

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -641,10 +641,11 @@ def main(args: argparse.Namespace):
     dimensions_json["date"] = current_dt
     dimensions_json["model_id"] = model_id
     dimensions_json["tokenizer_id"] = tokenizer_id
-    dimensions_json = {
-        **dimensions_json,
-        **json.loads(args.additional_metadata_metrics_to_save),
-    }
+    if args.additional_metadata_metrics_to_save is not None:
+      dimensions_json = {
+          **dimensions_json,
+          **json.loads(args.additional_metadata_metrics_to_save),
+      }
     metrics_json["num_prompts"] = args.num_prompts
 
     # Traffic


### PR DESCRIPTION
if `args.additional_metadata_metrics_to_save` is None, `json.loads` would fail. `args.additional_metadata_metrics_to_save` is None by default. Adding a check to avoid the failure.

Test:
Using the benchmark example script in `README`
```
python JetStream/benchmarks/benchmark_serving.py   \
--tokenizer ~/maxtext/assets/tokenizer.llama2  \
--warmup-mode full   \
--save-result   \
--save-request-outputs   \
--request-outputs-file-path outputs.json   \
--num-prompts 1000   \
--max-output-length 1024   \
--dataset openorca
```