### PR TITLE
Free engine resource for the slot after finished one request decoding

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -784,6 +784,7 @@ class Driver:
               # Place the slot back on the free queue.
               my_live_requests[slot] = None
               my_slots.put(slot, block=False)  # This should always have space.
+              my_generate_engine.free_resource(slot)
         logging.info(
             "Detokenizing generate step %d took %.2fms",
             generate_timestep_added,

--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -189,7 +189,7 @@ class Engine(abc.ABC):
 
   def free_resource(
       self,
-      slot: int, # pylint: disable=unused-argument
+      slot: int,  # pylint: disable=unused-argument
   ) -> Any:
     """Free cache and other decode resource for the slot.
 

--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -186,6 +186,18 @@ class Engine(abc.ABC):
     and batch), but at the engine interface level all of these are exposed as
     a [0, n) range of slots and converted internally.
     """
+ 
+  def free_resource(
+      self,
+      slot: int,
+  ) -> Any:
+    """Free cache and other decode resource for the slot.
+
+    This function is needed for advanced attetnion kenel like PageAttetion. After
+    finishing one request, the engine need to free all used page block resource 
+    and reuse for coming requests. 
+    """
+    return None   
 
   @abc.abstractmethod
   def load_params(self, *args, **kwargs) -> Params:

--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -186,18 +186,18 @@ class Engine(abc.ABC):
     and batch), but at the engine interface level all of these are exposed as
     a [0, n) range of slots and converted internally.
     """
- 
+
   def free_resource(
       self,
-      slot: int,
+      slot: int, # pylint: disable=unused-argument
   ) -> Any:
     """Free cache and other decode resource for the slot.
 
-    This function is needed for advanced attetnion kenel like PageAttetion. After
-    finishing one request, the engine need to free all used page block resource 
-    and reuse for coming requests. 
+    This function is needed for advanced attetnion kenel like PageAttetion.
+    After finishing one request, the engine need to free all used page block
+    resource and reuse for coming requests.
     """
-    return None   
+    return None
 
   @abc.abstractmethod
   def load_params(self, *args, **kwargs) -> Params:


### PR DESCRIPTION
This PR add one feature: free engine resource (cache and other resource) after completing a request. 

Advance kennel like PageAttention reserve page block for different tokens in insert and decode, all these reserve resource  must be free after completing the decode of a request, the free page block can be reused for coming requests. 

Once all engine implement this function, will force this function as abstractmethod. 