### PR TITLE
Add `jetstream_request_success_count` metric

### DIFF
--- a/jetstream/core/metrics/prometheus.py
+++ b/jetstream/core/metrics/prometheus.py
@@ -77,4 +77,4 @@ class JetstreamMetricsCollector:
     return self._server_startup_latency.labels(id=self._id)
 
   def get_request_success_count_metric(self):
-    return self._request_success_counter.labels(id=self._id)
+    return self._request_success_count.labels(id=self._id)

--- a/jetstream/core/metrics/prometheus.py
+++ b/jetstream/core/metrics/prometheus.py
@@ -16,7 +16,7 @@
 
 import os
 import shortuuid
-from prometheus_client import Gauge
+from prometheus_client import Count, Gauge
 
 
 class JetstreamMetricsCollector:
@@ -55,6 +55,11 @@ class JetstreamMetricsCollector:
       documentation="Total time taken to start the Jetstream server",
       labelnames=["id"],
   )
+  _request_success_count = Count(
+      name="jetstream_request_success_count",
+      documentation="Number of requests successfully completed",
+      labelnames=["id"],
+  )
 
   def get_prefill_backlog_metric(self):
     return self._prefill_backlog.labels(id=self._id)
@@ -70,3 +75,6 @@ class JetstreamMetricsCollector:
 
   def get_server_startup_latency_metric(self):
     return self._server_startup_latency.labels(id=self._id)
+
+  def get_request_success_count_metric(self):
+    return self._request_success_counter.labels(id=self._id)

--- a/jetstream/core/metrics/prometheus.py
+++ b/jetstream/core/metrics/prometheus.py
@@ -16,7 +16,7 @@
 
 import os
 import shortuuid
-from prometheus_client import Count, Gauge
+from prometheus_client import Counter, Gauge
 
 
 class JetstreamMetricsCollector:
@@ -55,7 +55,7 @@ class JetstreamMetricsCollector:
       documentation="Total time taken to start the Jetstream server",
       labelnames=["id"],
   )
-  _request_success_count = Count(
+  _request_success_count = Counter(
       name="jetstream_request_success_count",
       documentation="Number of requests successfully completed",
       labelnames=["id"],

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -780,6 +780,8 @@ class Driver:
             # Return some output samples.
             request.enqueue_samples(results)
             if request.complete.all():
+              if self._metrics_collector:
+                self._metrics_collector.get_request_success_count_metric().inc()
               request.return_channel.close()
               # Place the slot back on the free queue.
               my_live_requests[slot] = None


### PR DESCRIPTION
Scrape results after running the following command:
```
seq 100 | xargs -P 100 -n 1 curl --request POST --header "Content-type: application/json" -s localhost:8000/generate --data '{
    "prompt": "Can you provide a comprehensive and detailed overview of the history and development of artificial intelligence.",
    "max_tokens": 200
}'
```

```
# HELP jetstream_request_success_count_total Number of requests successfully completed
# TYPE jetstream_request_success_count_total counter
jetstream_request_success_count_total{id="maxengine-server-5b6c99588c-z4ldf"} 100.0
```