### PR TITLE
Manual model warmup to resolve AOT model warmup performance degradation

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -134,7 +134,6 @@ class ActiveRequest:
   prefill_result: Any = None
   #################### Information relevant for prefill ########################
   prefill_content: Optional[str | list[int]] = None
-  padded_token_length: Optional[int] = None
   ################## Information relevant for detokenization ###################
   # Which generate step this was added at.
   generate_timestep_added: Optional[int] = None
@@ -509,7 +508,6 @@ class Driver:
           padded_tokens=padded_tokens,
           true_length=true_length,
       )
-
       request.prefill_result = prefill_result
 
       # put first token to detokenize queue

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -502,11 +502,6 @@ class Driver:
       padded_tokens, true_length = self._process_prefill_content(
           request, tokenizer, is_bos, prefill_engine.max_prefill_length
       )
-      if isinstance(prefill_engine, engine_api.JetStreamEngine):
-        request.padded_token_length = token_utils.take_nearest_length(
-            prefill_engine.prefill_buckets, true_length
-        )
-        prefill_engine.set_padded_token_length(request.padded_token_length)
 
       # Compute new kv cache for the prefill_content.
       prefill_result, first_token = prefill_engine.prefill(
@@ -677,11 +672,6 @@ class Driver:
             slot,
             generate_timestep,
         )
-
-        if isinstance(generate_engine, engine_api.JetStreamEngine):
-          generate_engine.set_padded_token_length(
-              new_request.padded_token_length
-          )
 
         decode_state = generate_engine.insert(
             new_request.prefill_result, decode_state, slot=slot

--- a/jetstream/core/server_lib.py
+++ b/jetstream/core/server_lib.py
@@ -34,7 +34,7 @@ from jetstream.core import config_lib
 from jetstream.core import orchestrator
 from jetstream.core.metrics.prometheus import JetstreamMetricsCollector
 from jetstream.core.proto import jetstream_pb2_grpc
-from jetstream.engine import aot_utils, engine_api
+from jetstream.engine import warmup_utils, engine_api
 
 from prometheus_client import start_http_server
 
@@ -107,7 +107,7 @@ def create_driver(
     devices: Device objects, will be used to get engine with proper slicing.
     jax_padding: The flag to enable JAX padding during tokenization.
     metrics_collector: The JetStream Promethus metric collector.
-    enable_model_warmup: The flag to enable model server warmup with AOT.
+    enable_model_warmup: The flag to enable model server warmup.
 
   Returns:
     An orchestrator driver.
@@ -142,7 +142,7 @@ def create_driver(
     ]
 
     try:
-      _ = aot_utils.layout_params_and_compile_executables(
+      _ = warmup_utils.layout_params_and_compile_executables(
           prefill_engines,  # pylint: disable=protected-access
           generate_engines,  # pylint: disable=protected-access
           prefill_params,  # pylint: disable=protected-access
@@ -191,7 +191,7 @@ def run(
     metrics_server_config: The config to enable Promethus metric server.
     enable_jax_profiler: The flag to enable JAX profiler server.
     jax_profiler_port: The port JAX profiler server (default to 9999).
-    enable_model_warmup: The flag to enable model server warmup with AOT.
+    enable_model_warmup: The flag to enable model server warmup.
 
   Returns:
     JetStreamServer that wraps the grpc server and orchestrator driver.

--- a/jetstream/engine/aot_utils.py
+++ b/jetstream/engine/aot_utils.py
@@ -58,7 +58,7 @@ def layout_params_and_compile_executables(
     prefills_compiled.append(prefill_compiled)
 
   for i, ge in enumerate(generate_engines):
-    insert_compiled, generate_compiled = (
+    insert_generate_compiled = (
         initialize_insert_generate_jit_cache(
             prefill_engine=any_prefill_engine,
             generate_engine=ge,
@@ -68,7 +68,7 @@ def layout_params_and_compile_executables(
         )
     )
     inserts_generate_compiled.append(
-        [insert_compiled, generate_compiled]
+        [insert_generate_compiled]
     )
 
   if prefills_compiled and inserts_generate_compiled:
@@ -221,4 +221,4 @@ def initialize_insert_generate_jit_cache(
       generate_idx,
   )
 
-  return insert_executable, generate_executable
+  return generate_engine.warm

--- a/jetstream/engine/aot_utils.py
+++ b/jetstream/engine/aot_utils.py
@@ -14,10 +14,9 @@
 
 """AOT compilation utils."""
 
-import jax
 import jax.numpy as jnp
 import concurrent.futures
-from typing import Any, Optional, cast
+from typing import Any, Optional
 import logging
 from jetstream.engine import engine_api, token_utils
 
@@ -58,18 +57,14 @@ def layout_params_and_compile_executables(
     prefills_compiled.append(prefill_compiled)
 
   for i, ge in enumerate(generate_engines):
-    insert_generate_compiled = (
-        initialize_insert_generate_jit_cache(
-            prefill_engine=any_prefill_engine,
-            generate_engine=ge,
-            prefill_params=any_prefill_params,
-            generate_params=generate_params[i],
-            generate_idx=i,
-        )
+    insert_generate_compiled = initialize_insert_generate_jit_cache(
+        prefill_engine=any_prefill_engine,
+        generate_engine=ge,
+        prefill_params=any_prefill_params,
+        generate_params=generate_params[i],
+        generate_idx=i,
     )
-    inserts_generate_compiled.append(
-        [insert_generate_compiled]
-    )
+    inserts_generate_compiled.append([insert_generate_compiled])
 
   if prefills_compiled and inserts_generate_compiled:
     return True
@@ -104,7 +99,7 @@ def initialize_prefill_jit_cache(
   def compile_prefill(length):
     padded_tokens, true_length = jnp.ones((length), dtype="int32"), length
 
-    _, _ = prefill_engine._downstream_engine.prefill(
+    _, _ = prefill_engine._downstream_engine.prefill(  # pylint: disable=protected-access
         params=prefill_params,
         padded_tokens=padded_tokens,
         true_length=true_length,
@@ -183,7 +178,7 @@ def initialize_insert_generate_jit_cache(
         "---------Generate compilation %d begun.---------", generate_idx
     )
 
-    generate_engine._downstream_engine.generate(
+    generate_engine._downstream_engine.generate(  # pylint: disable=protected-access
         params=generate_params,
         decode_state=decode_state,
     )

--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -276,9 +276,9 @@ class JetStreamEngine(Engine):
   ) -> Tuple[Prefix, ResultTokens]:
 
     prefill_result, first_token = self._downstream_engine.prefill(
-      params=params,
-      padded_tokens=padded_tokens,
-      true_length=true_length,
+        params=params,
+        padded_tokens=padded_tokens,
+        true_length=true_length,
     )
     return prefill_result, first_token
 
@@ -290,9 +290,9 @@ class JetStreamEngine(Engine):
   ) -> DecodeState:
 
     decode_state = self._downstream_engine.insert(
-      prefix=prefix,
-      decode_state=decode_state,
-      slot=slot,
+        prefix=prefix,
+        decode_state=decode_state,
+        slot=slot,
     )
     return decode_state
 
@@ -300,7 +300,7 @@ class JetStreamEngine(Engine):
       self, params: Params, decode_state: DecodeState
   ) -> Tuple[DecodeState, ResultTokens]:
     decode_state, sampled_tokens = self._downstream_engine.generate(
-      params=params, decode_state=decode_state
+        params=params, decode_state=decode_state
     )
     return decode_state, sampled_tokens
 
@@ -344,4 +344,3 @@ class JetStreamEngine(Engine):
   @property
   def colocated_cpus(self) -> Union[list[CpuDevices], None]:
     return self._downstream_engine.colocated_cpus
-

--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -257,7 +257,7 @@ class Engine(abc.ABC):
 class JetStreamEngine(Engine):
   """A wrapper engine of the Engine class.
 
-  JetStreamEngine defines the AOT warmed up model server engine.
+  JetStreamEngine defines the warmed up model server engine.
   """
 
   def __init__(self, downstream_engine: Engine):

--- a/jetstream/engine/warmup_utils.py
+++ b/jetstream/engine/warmup_utils.py
@@ -66,7 +66,7 @@ def layout_params_and_compile_executables(
     )
     inserts_generate_compiled.append([insert_generate_compiled])
 
-  if any(prefills_compiled) and any(inserts_generate_compiled):
+  if all(prefills_compiled) and all(inserts_generate_compiled):
     return True
   return False
 

--- a/jetstream/engine/warmup_utils.py
+++ b/jetstream/engine/warmup_utils.py
@@ -66,7 +66,7 @@ def layout_params_and_compile_executables(
     )
     inserts_generate_compiled.append([insert_generate_compiled])
 
-  if prefills_compiled and inserts_generate_compiled:
+  if any(prefills_compiled) and any(inserts_generate_compiled):
     return True
   return False
 

--- a/jetstream/engine/warmup_utils.py
+++ b/jetstream/engine/warmup_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""AOT compilation utils."""
+"""Model server warmup utils."""
 
 import jax.numpy as jnp
 import concurrent.futures


### PR DESCRIPTION
Use manual model warmup instead of AOT implemented model warmup, since with AOT, we observe performance degradation at higher batch size of maxtext configuration, mentioned in https://github.com/google/JetStream/pull/92:
1. OOM at higher batch size (after model warmup, during an active request)
2. Slower detokenizing generate step time exponentially at higher batch sizes

This has been verified that the detokenizing generate step time remains same as JetStream optimal behavior for all batch sizes. 


```
curl --request POST --header "Content-type: application/json"
 -s localhost:8000/generate --data '{
    "prompt": "What are the top 5 programming languages",
    "max_tokens": 200
}'
{
    "response": " for data science in 2023?\n\n1. Python\n2. R\n3. SQL\n4. Java\n5. Scala\n\n**Note:** The order is based on popularity and demand in the data science industry in 2023."
}
```